### PR TITLE
Get back from the cache

### DIFF
--- a/addendum/models.py
+++ b/addendum/models.py
@@ -65,6 +65,7 @@ def get_cached_snippet(key, language=''):
             snippet = {'': None}
         else:
             set_cached_snippet(key)
+            snippet = cache.get('snippet:{0}'.format(key))
 
     return snippet.get(language, snippet.get(''))
 


### PR DESCRIPTION
In get_cached_snippet, when the snippet is not in the cache it is retrieved from the DB
```python
snippet = Snippet.objects.get(key=key)
```
However a few line after the get method is called on the snippet object.
'Snippet' object has no attribute 'get'

(it is because we are expecting that 
```python
snippet = cache.get('snippet:{0}'.format(key)) 
```

To solve that I just retrive the snippet from the cache, once I have setted it.