### PR TITLE
add edit links if the user is staff

### DIFF
--- a/addendum/templatetags/addendum_tags.py
+++ b/addendum/templatetags/addendum_tags.py
@@ -4,7 +4,7 @@ from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.core.urlresolvers import reverse
 from urllib.parse import urlencode
-from ..models import get_cached_snippet, Snippet
+from ..models import get_cached_snippet
 
 
 register = template.Library()
@@ -104,7 +104,8 @@ class SnippetNode(template.Node):
             if snippet:
                 url = reverse('admin:addendum_snippet_change', args=(key,)) + '?_popup=1'
             else:
-                url = reverse('admin:addendum_snippet_add') + '?' + urlencode({'_popup': 1, 'key': key, 'text': self.nodelist.render(context)})
+                query = urlencode({'_popup': 1, 'key': key, 'text': self.nodelist.render(context)})
+                url = reverse('admin:addendum_snippet_add') + '?' + query
 
             link = mark_safe('<br><a class="btn btn-xs popup" href="{}">Edit</a>'.format(url))
         else:

--- a/addendum/templatetags/addendum_tags.py
+++ b/addendum/templatetags/addendum_tags.py
@@ -2,8 +2,9 @@ from django import template
 from django.template.base import TemplateSyntaxError
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
-
-from ..models import get_cached_snippet
+from django.core.urlresolvers import reverse
+from urllib.parse import urlencode
+from ..models import get_cached_snippet, Snippet
 
 
 register = template.Library()
@@ -99,9 +100,21 @@ class SnippetNode(template.Node):
 
         snippet = get_cached_snippet(key, language)
 
+        if context.request.user.is_staff:
+            if snippet:
+                url = reverse('admin:addendum_snippet_change', args=(key,)) + '?_popup=1'
+            else:
+                url = reverse('admin:addendum_snippet_add') + '?' + urlencode({'_popup': 1, 'key': key, 'text': self.nodelist.render(context)})
+
+            link = mark_safe('<br><a class="btn btn-xs popup" href="{}">Edit</a>'.format(url))
+        else:
+            link = ""
+
         if snippet is None:
-            output = self.nodelist.render(context)
+            output = self.nodelist.render(context) + link
             return output
+
+        snippet += link
 
         if self.template:
             if self.safe:


### PR DESCRIPTION
This quick patch add a link 'Edit' to each snippet if the user is staff member.  If the snippet will be added for first time, it prepolute the key and the text. 

