### PR TITLE
Admin form: extra languages = 0 workaround

### DIFF
--- a/addendum/admin.py
+++ b/addendum/admin.py
@@ -8,7 +8,7 @@ from .models import Snippet, SnippetTranslation
 class TranslationAdmin(admin.TabularInline):
     model = SnippetTranslation
     form = TranslationForm
-    extra = 1
+    extra = 0
 
 
 class SnippetAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Django doesn't let you save the snippet otherwise, because it says that "Text" must be filled in. For other forms django would see that nothing was filled in, but becaues you cannot put no value into the dropdown it thinks there is a value.

![image](https://cloud.githubusercontent.com/assets/4520820/11103098/bbe0674e-88c0-11e5-88c1-f1f20b743757.png)

It might also be because I use a special environment with [djangae](https://github.com/potatolondon/djangae), but that is not obviously related to the issue.
At least it fixes the problem for me.