### PR TITLE
Fix and simplify addendum_tags.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - TOX_ENV=py27-django18
   - TOX_ENV=py27-django17
   - TOX_ENV=py27-django16
-  - TOX_ENV=py27-django14
   - TOX_ENV=pypy-django19
   - TOX_ENV=pypy-django18
 install:

--- a/addendum/templatetags/addendum_tags.py
+++ b/addendum/templatetags/addendum_tags.py
@@ -94,11 +94,13 @@ class SnippetNode(template.Node):
             self.safe = self.safe.resolve(context)
 
         if self.template:
-            rendered = template.Template(snippet).render(context)
             if self.safe:
+                old_autoescape = context.autoescape
                 context.autoescape = False
+                rendered = template.Template(snippet).render(context)
+                context.autoescape = old_autoescape
                 return mark_safe(rendered)
-            return rendered
+            return template.Template(snippet).render(context)
 
         if self.safe:
             return mark_safe(snippet)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -60,6 +60,20 @@ class TagTests(TestCase):
         result = t.render(c)
         self.assertEqual(result, "<h1>Hello, humans</h1>")
 
+    def test_safe(self):
+        """Ensure that with safe argument content is escaped"""
+        t = Template("""{% load addendum_tags %}{% snippet 'rich' safe=True %}Hello world{% endsnippet %}""")
+        c = Context({})
+        result = t.render(c)
+        self.assertEqual(result, "<h1>Hello, humans</h1>")
+
+    def test_safe_false(self):
+        """Ensure that with safe argument which is False content is not escaped"""
+        t = Template("""{% load addendum_tags %}{% snippet 'rich' safe=isallowed %}Hello world{% endsnippet %}""")
+        c = Context({'isallowed': False})
+        result = t.render(c)
+        self.assertEqual(result, "&lt;h1&gt;Hello, humans&lt;/h1&gt;")
+
     def test_raw_template_text(self):
         """Ensure template code is not compiled by default"""
         t = Template("""{% load addendum_tags %}{% snippet 'django' %}Hello world{% endsnippet %}""")
@@ -80,10 +94,10 @@ class TagTests(TestCase):
         result = t.render(c)
         self.assertEqual(result, "&lt;H1&gt;WOOF&lt;/H1&gt;")
 
-        t = Template("""{% load addendum_tags %}{% snippet 'django' template=True safe=True %}Hello world{% endsnippet %}""")
-        c = Context({'dog': '<h1>woof</h1>'})
+        t = Template("""{% load addendum_tags %}{% snippet 'django' template=True safe=True %}Hello world{% endsnippet %} {{ after }}""")
+        c = Context({'dog': '<h1>woof</h1>', 'after': '<h1>no longer safe</h1>'})
         result = t.render(c)
-        self.assertEqual(result, "<H1>WOOF</H1>")
+        self.assertEqual(result, "<H1>WOOF</H1> &lt;h1&gt;no longer safe&lt;/h1&gt;")
 
     def test_variable_key_name(self):
         """Ensure a variable can be passed for the snippet key"""

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py35-django{19,18},
     py34-django{19,18,17},
     py33-django{18,17},
-    py27-django{19,18,17,16,14}
+    py27-django{19,18,17,16}
 
 [testenv]
 setenv =
@@ -17,7 +17,6 @@ basepython =
     py35: python3.5
     pypy: pypy
 deps =
-    django14: Django>=1.4,<1.5
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8


### PR DESCRIPTION
This fixe some bugs and makes the code cleaner.

str_bool was not used.
The split_content part was complicated and even wrong, tag_name ened up as a list.
In the renderer, self.key and self.language are always Variables or None, never strings.
self.safe was not resolved before, it was simply True when it was defined (even safe=False was interpreted as safe).