### PR TITLE
Automatically add snippet to db when rendering

### DIFF
--- a/addendum/templatetags/addendum_tags.py
+++ b/addendum/templatetags/addendum_tags.py
@@ -3,7 +3,7 @@ from django.template.base import TemplateSyntaxError
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
-from ..models import get_cached_snippet
+from ..models import get_cached_snippet, Snippet
 
 
 register = template.Library()
@@ -101,6 +101,8 @@ class SnippetNode(template.Node):
 
         if snippet is None:
             output = self.nodelist.render(context)
+            snippet = Snippet(key=key, text=output)
+            snippet.save()
             return output
 
         if self.template:


### PR DESCRIPTION
This is an idea to simplify making changes in the admin interface.
Before, you needed to know the identifier and create the snippet in the admin.
With this changes, a snippet is automatically added to the db with its rendered content when it is first rendered. Now you only have to add a new snippet tag in the template and it immediately appears in the admin (after visiting the page containing the snippet).

What do you think of this idea?