### PR TITLE
Only add addendum to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author_email='ben.lopatin@wellfireinteractive.com',
     url='https://github.com/bennylope/django-addendum',
     license='BSD License',
-    packages=find_packages(exclude=('example', 'docs')),
+    packages=['addendum'],
     platforms=['OS Independent'],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Before this, `pip install` also installed the tests folder, directly into `site-packages`.

It might be better to move the `tests` folder into `addendum`, but I was not sure what I'd need to change in the various config files.