### PR TITLE
Revert #10 and add better solution

### DIFF
--- a/addendum/admin.py
+++ b/addendum/admin.py
@@ -8,7 +8,7 @@ from .models import Snippet, SnippetTranslation
 class TranslationAdmin(admin.TabularInline):
     model = SnippetTranslation
     form = TranslationForm
-    extra = 0
+    extra = 1
 
 
 class SnippetAdmin(admin.ModelAdmin):

--- a/addendum/forms.py
+++ b/addendum/forms.py
@@ -8,7 +8,7 @@ from .models import SnippetTranslation
 
 class TranslationForm(forms.ModelForm):
 
-    language = forms.ChoiceField(choices=settings.LANGUAGES)
+    language = forms.ChoiceField(choices=settings.LANGUAGES, initial='en')
 
     class Meta:
         model = SnippetTranslation


### PR DESCRIPTION
This actually fixes the issue instead of working around it (#10). Without an initial value, django admin always thinks that the value was changed, as it can't be empty.